### PR TITLE
Create a GitHub Actions integration test workflow

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,34 @@
+name: Integration Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CI: true
+
+jobs:
+  test:
+    if: ${{ github.repository == 'Ally-Guide/amplify-back-end' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+      - name: Setup node
+        uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f
+        with:
+          node-version: 16.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- server/__tests__/integration/
+        env:
+          CIVIC_API_KEY: ${{ secrets.TEST_CIVIC_API_KEY }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -31,4 +31,10 @@ jobs:
       - name: Run tests
         run: npm test -- server/__tests__/integration/
         env:
+          # Google Civic API key
           CIVIC_API_KEY: ${{ secrets.TEST_CIVIC_API_KEY }}
+          # Auth0 authentication parameters with nonsensical sample values
+          ISSUER_BASE_URL: https://YOUR_AUTH_DOMAIN
+          CLIENT_ID: YOUR_CLIENT_ID
+          BASE_URL: https://localhost:5000/
+          SECRET: LONG_RANDOM_VALUE

--- a/server/__tests__/integration/amplify.test.js
+++ b/server/__tests__/integration/amplify.test.js
@@ -19,7 +19,7 @@ describe('/api/amplify/:zipcode', () => {
     })
 })
 
-describe('/api/amplify/', () => {
+describe.skip('/api/amplify/', () => {
     const route = '/api/amplify/'
     test('returns 200 status', async () => {
         const response = await request(app).get(route)

--- a/server/routes/api/amplify.js
+++ b/server/routes/api/amplify.js
@@ -117,7 +117,7 @@ function CheckUndefined(itemToCheck, repInfo) {
 
 module.exports = router
 
-// Temporary implemntation for fallback with deprecation warnings
+// Temporary implementation for fallback with deprecation warnings
 function getCivicApiKey() {
     const { CIVIC_API_KEY, CivicAPI } = process.env
     const civicApiKey = CIVIC_API_KEY || CivicAPI


### PR DESCRIPTION
### Why?

Closes #26 

### What Changed?

- Added a new GitHub Actions workflow to run the integration tests on pushes to `main` and internal PRs (won't work on PRs from forked repositories)
- Marked the tests for `/api/amplify/` (without a zip code specified) as skipped since the endpoint is currently commented out
- Fixed a typo 😅 

#### TODO

- [ ] Need to add an Actions Secret called `TEST_CIVIC_API_KEY` with a new **separate** Google Civic API key
  - I have _**temporarily**_ added a testing API key from my personal Google account