### PR TITLE
Add API endpoint to verify address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,15 @@
 # See https://github.com/Ally-Guide/amplify-back-end/blob/main/.github/CONTRIBUTING.md#using-the-google-civic-information-api-locally
 CIVIC_API_KEY=
 
+# Production environment API key for the Lob API
+# This value can be found in Heroku application config var of the same name
+LOB_API_KEY=
+
+# Test environment API key for the Lob API
+# This is only required for running the integration tests successfully!
+# This value can be found in Heroku application config var of the same name
+TEST_LOB_API_KEY=
+
 # Auth0 authentication parameters
 # For local development, you can just use these literal nonsense values for now
 ISSUER_BASE_URL=https://YOUR_AUTH_DOMAIN

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -115,6 +115,30 @@ CIVIC_API_KEY=<YOUR_API_KEY>
 
 7. Save the changes to the `.env` file.
 
+#### Using the Lob API locally
+
+1. Login to your personal [Heroku dashboard](https://dashboard.heroku.com/).
+2. Switch to the `programequity` team under the project dropdown (which probably defaulted to `Personal`).
+  - :information_source: If you do not see that team, you probably need to be added by a project administrator.
+3. Go into the backend application, currently named `murmuring-headland-63935`.
+4. Go into the "Settings" tab.
+5. In the "Config Vars" section, click the "Reveal Config Vars" button to expand the list of existing environment variables.
+6. Find the `LOB_API_KEY` and `TEST_LOB_API_KEY` variables.
+7. Create a file called  `.env` in the project's root directory, preferrably using the `.env.example` file as your template.
+8. Add a set of new key-value pairs to the file containing the API keys with the values from the Heroku application, e.g.
+
+```
+# Production environment API key for the Lob API
+LOB_API_KEY=<HEROKU_VARIABLE>
+
+# Test environment API key for the Lob API
+# This is only required for running the integration tests successfully!
+TEST_LOB_API_KEY=<HEROKU_VARIABLE>
+```
+
+9. Save the changes to the `.env` file.
+
+
 #### Ignoring the Auth0 authentication locally
 
 Although the authentication check is not required locally, the module in use still expects certain values to be passed in regardless of their validity.

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,6 +33,8 @@ jobs:
         env:
           # Google Civic API key
           CIVIC_API_KEY: ${{ secrets.TEST_CIVIC_API_KEY }}
+          # Test environment Lob API key
+          LOB_API_KEY: ${{ secrets.TEST_LOB_API_KEY }}
           # Auth0 authentication parameters with nonsensical sample values
           ISSUER_BASE_URL: https://YOUR_AUTH_DOMAIN
           CLIENT_ID: YOUR_CLIENT_ID

--- a/package-lock.json
+++ b/package-lock.json
@@ -1198,7 +1198,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1318,7 +1317,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -1326,8 +1324,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1344,8 +1341,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -1356,14 +1352,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
       "version": "0.21.1",
@@ -1512,7 +1506,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -1522,6 +1515,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -1713,8 +1711,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "cb": {
       "version": "0.1.0",
@@ -1961,7 +1958,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2044,8 +2040,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.8.5",
@@ -2100,7 +2095,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -2188,8 +2182,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -2263,7 +2256,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -2890,8 +2882,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2948,20 +2939,17 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3056,14 +3044,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -3177,7 +3163,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -3266,14 +3251,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -3399,7 +3382,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -3677,8 +3659,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -3723,8 +3704,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -4692,8 +4672,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "16.5.3",
@@ -4758,14 +4737,12 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4776,8 +4753,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.0",
@@ -4792,7 +4768,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -4896,6 +4871,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
+    },
+    "lob": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lob/-/lob-6.2.0.tgz",
+      "integrity": "sha512-lFIV9wgqTDLDS2fcIWqL/WDFpEZ6kjETos7nlnm1uAVfE4sP3S6u6kLoGL/OzmCRfdCGalwXiybwMq//ZuccCg==",
+      "requires": {
+        "bluebird": "^3.0.6",
+        "request": "^2.88.0"
+      }
     },
     "locate-path": {
       "version": "5.0.0",
@@ -5269,8 +5253,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -5698,8 +5681,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
       "version": "8.6.0",
@@ -5881,8 +5863,7 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "pstree.remy": {
       "version": "1.1.8",
@@ -5902,8 +5883,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.1.1",
@@ -6072,7 +6052,6 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -6099,14 +6078,12 @@
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "tough-cookie": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "dev": true,
           "requires": {
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
@@ -6115,8 +6092,7 @@
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -6903,7 +6879,6 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -7448,7 +7423,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -7456,8 +7430,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.4.0",
@@ -7612,7 +7585,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -7704,7 +7676,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "express": "^4.17.1",
     "express-openid-connect": "^2.3.1",
     "knex": "^0.95.5",
+    "lob": "^6.2.0",
     "pg": "^8.6.0"
   },
   "devDependencies": {

--- a/server/__tests__/integration/lob.test.js
+++ b/server/__tests__/integration/lob.test.js
@@ -1,0 +1,86 @@
+require('dotenv').config()
+const app = require('../../app')
+const request = require('supertest')
+
+const LOB_TEST_KEY_PREFIX = 'test_'
+
+// Ensure we are using a testing key for the Lob API.
+// Many of the tests will fail if using a live key instead.
+beforeAll(() => {
+    const { LOB_API_KEY, TEST_LOB_API_KEY } = process.env
+    let lobApiKey = LOB_API_KEY || ''
+
+    // Lob API keys starts with either "live_" (production) or "test_" (testing)
+    if (!lobApiKey.startsWith(LOB_TEST_KEY_PREFIX) && (TEST_LOB_API_KEY || '').startsWith(LOB_TEST_KEY_PREFIX)) {
+        lobApiKey = TEST_LOB_API_KEY
+    }
+
+    if (!lobApiKey.startsWith(LOB_TEST_KEY_PREFIX)) {
+        throw new Error('You must use a test environment Lob API key!')
+    }
+
+    process.env.LOB_API_KEY = lobApiKey
+})
+
+afterEach(() => {
+    jest.clearAllMocks()
+})
+
+afterAll(async () => {
+    await new Promise((resolve) => setTimeout(() => resolve(), 500)) // avoid jest open handle error
+})
+
+describe('GET /api/lob/templates/:templateId', () => {
+    const templateId = '1234'
+    const route = `/api/lob/templates/${templateId}`
+
+    test('returns 200 status for an existing template', async () => {
+        const response = await request(app).get(route)
+        expect(response.status).toBe(200)
+    })
+
+    test('returns 400 status for a non-existent template', async () => {
+        const badRoute = `/api/lob/templates/non_existent_template_id`
+        const response = await request(app).get(badRoute)
+        expect(response.status).toBe(400)
+        expect(response.body.error).toBe('template not found')
+    })
+
+    test('temporarily supports deprecated route /api/lob/:templateId', async () => {
+      const deprecatedRoute = `/api/lob/${templateId}`
+  
+      const response = await request(app).get(deprecatedRoute)
+      expect(response.status).toBe(200)
+    })
+})
+
+describe('POST /api/lob/addressVerification', () => {
+    // For more information on these testing values, check the Lob API docs.
+    // See: https://docs.lob.com/node#us-verification-test-environment
+
+    const route = '/api/lob/addressVerification'
+    const zip = '11111' // nonsense
+
+    test('returns 200 status for an address meeting all requirements', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'residential house', zip })
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual({
+            deliverable: true,
+            warning: null,
+            revisedAddress: {
+                line1: '1709 BRODERICK ST',
+                line2: null,
+                city: 'SAN FRANCISCO',
+                state: 'CA',
+                zip: '94115-2525'
+            }
+        })
+    })
+
+    // Pre-request validation tests
+
+    // Post-request validation tests
+
+})

--- a/server/__tests__/integration/lob.test.js
+++ b/server/__tests__/integration/lob.test.js
@@ -1,7 +1,9 @@
 require('dotenv').config()
 const app = require('../../app')
 const request = require('supertest')
+const axios = require('axios')
 
+const LOB_API_HOST = 'https://api.lob.com'
 const LOB_TEST_KEY_PREFIX = 'test_'
 
 // Ensure we are using a testing key for the Lob API.
@@ -31,26 +33,107 @@ afterAll(async () => {
 })
 
 describe('GET /api/lob/templates/:templateId', () => {
-    const templateId = '1234'
+    const templateId = 'tmpl_c94e83ca2cd5121'
     const route = `/api/lob/templates/${templateId}`
 
+    // From https://docs.lob.com/#templates_object
+    const someDate = '2017-11-07T22:56:10.962Z'
+    const exampleLobResponse = {
+      id: templateId,
+      description: 'Test Template',
+      versions: [
+        {
+          id: 'vrsn_362184d96d9b0c9',
+          description: 'Test Template',
+          html: '<html>HTML for {{name}}</html>',
+          date_created: someDate,
+          date_modified: someDate,
+          object: 'version'
+        }
+      ],
+      published_version: {
+        id: 'vrsn_362184d96d9b0c9',
+        description: 'Test Template',
+        html: '<html>HTML for {{name}}</html>',
+        date_created: someDate,
+        date_modified: someDate,
+        object: 'version'
+      },
+      metadata: {},
+      date_created: someDate,
+      date_modified: someDate,
+      object: 'template'
+    }
+
     test('returns 200 status for an existing template', async () => {
+        const spy = jest.spyOn(axios, 'get')
+        spy.mockImplementation((url) => {
+          if (url !== `${LOB_API_HOST}/v1/templates/${templateId}`) {
+              throw new Error('unexpected call to `axios.get`')
+          }
+          return {
+              status: 200,
+              data: exampleLobResponse
+          }
+        })
+
         const response = await request(app).get(route)
         expect(response.status).toBe(200)
+
+        expect(spy).toHaveBeenCalled()
+        spy.mockRestore()
     })
 
     test('returns 400 status for a non-existent template', async () => {
-        const badRoute = `/api/lob/templates/non_existent_template_id`
+        const badTemplateId = 'non_existent_template_id'
+        const badRoute = `/api/lob/templates/${badTemplateId}`
+
+        const spy = jest.spyOn(axios, 'get')
+        spy.mockImplementation((url) => {
+            if (url !== `${LOB_API_HOST}/v1/templates/${badTemplateId}`) {
+                throw new Error('unexpected call to `axios.get`')
+            }
+
+            const axiosError = new Error('Not Found')
+            axiosError.response = {
+                status: 404,
+                data: {
+                    error: {
+                        message: 'template not found',
+                        status_code: 404,
+                        code: 'not_found'
+                    }
+                }
+            }
+            throw axiosError
+        })
+
         const response = await request(app).get(badRoute)
         expect(response.status).toBe(400)
         expect(response.body.error).toBe('template not found')
+
+        expect(spy).toHaveBeenCalled()
+        spy.mockRestore()
     })
 
     test('temporarily supports deprecated route /api/lob/:templateId', async () => {
-      const deprecatedRoute = `/api/lob/${templateId}`
-  
-      const response = await request(app).get(deprecatedRoute)
-      expect(response.status).toBe(200)
+        const spy = jest.spyOn(axios, 'get')
+        spy.mockImplementation((url) => {
+          if (url !== `${LOB_API_HOST}/v1/templates/${templateId}`) {
+              throw new Error('unexpected call to `axios.get`')
+          }
+          return {
+              status: 200,
+              data: exampleLobResponse
+          }
+        })
+
+        const deprecatedRoute = `/api/lob/${templateId}`
+        const response = await request(app).get(deprecatedRoute)
+        expect(response.status).toBe(200)
+
+        expect(spy).toHaveBeenCalled()
+        spy.mockRestore()
     })
 })
 

--- a/server/__tests__/integration/lob.test.js
+++ b/server/__tests__/integration/lob.test.js
@@ -162,8 +162,144 @@ describe('POST /api/lob/addressVerification', () => {
         })
     })
 
+    //
     // Pre-request validation tests
+    //
 
+    // TODO
+
+    //
     // Post-request validation tests
+    //
+
+    test('returns 200 status for a residential house', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'residential house', zip })
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual({
+            deliverable: true,
+            warning: null,
+            revisedAddress: {
+                line1: '1709 BRODERICK ST',
+                line2: null,
+                city: 'SAN FRANCISCO',
+                state: 'CA',
+                zip: '94115-2525'
+            }
+        })
+    })
+
+    test('returns 200 status for residential highrise', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'residential highrise', zip })
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual({
+            deliverable: true,
+            revisedAddress: {
+                city: 'SAN FRANCISCO',
+                line1: '660 KING ST UNIT 305',
+                line2: null,
+                state: 'CA',
+                zip: '94107-1539',
+            },
+            warning: null,
+        })
+    })
+
+    test('returns 200 status for residential department of state', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'department of state', zip })
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual({
+            deliverable: true,
+            revisedAddress: {
+                city: 'DPO',
+                line1: 'UNIT 8900 BOX 4301',
+                line2: null,
+                state: 'AE',
+                zip: '09831-4301',
+            },
+            warning: null,
+        })
+    })
+
+    test('returns 200 status for residential military', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'military', zip })
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual({
+            deliverable: true,
+            revisedAddress: {
+                city: 'APO',
+                line1: 'CMR 409 BOX 145',
+                line2: null,
+                state: 'AE',
+                zip: '09053-0002',
+            },
+            warning: null,
+        })
+    })
+
+    test('returns 200 status with warning for residence with unnecessary unit', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'unnecessary unit', zip })
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual({
+            deliverable: true,
+            revisedAddress: {
+                city: 'SAN FRANCISCO',
+                line1: '1709 BRODERICK ST APT 505',
+                line2: null,
+                state: 'CA',
+                zip: '94115-2525'
+            },
+            warning: 'Address may be deliverable but contains an unnecessary suite number'
+        })
+    })
+
+    test('returns 400 status for residential post office box', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'po box', zip })
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual({ error: 'Post office boxes are not currently supported' })
+    })
+
+    test('returns 400 status for residence in Puerto Rico', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'puerto rico', zip })
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual({ error: 'Puerto Rico addresses are not currently supported' })
+    })
+
+    test('returns 400 status for commercial building', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'deliverable', zip })
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual({ error: 'Non-residential addresses are not currently supported' })
+    })
+
+    test('returns 400 status for commercial highrise', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'commercial highrise', zip })
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual({ error: 'Non-residential addresses are not currently supported' })
+    })
+
+    test('returns 400 status for undeliverable address', async () => {
+        const response = await request(app)
+            .post(route)
+            .send({ line1: 'undeliverable block match', zip })
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual({ error: 'Address is undeliverable' })
+    })
 
 })

--- a/server/app.js
+++ b/server/app.js
@@ -10,8 +10,8 @@ app.use(
     })
 )
 
-//Middleware
-//app.use(express.json());
+// Middleware
+app.use(express.json());
 app.use(cors())
 
 const amplify = require('./routes/api/amplify');

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -110,24 +110,24 @@ router.post('/addressVerification', async (req, res) => {
             }
         } = response
 
-        const undeliverable = !deliverability || deliverability === 'undeliverable'
+        const isUndeliverable = !deliverability || deliverability === 'undeliverable'
         const isResidential = addressType === 'residential'
         const isPostOfficeBox = recordType === 'po_box'
         const isPuertoRico = revisedState === 'PR'
 
-        const deliverable = !undeliverable && isResidential && !isPostOfficeBox && !isPuertoRico
+        const deliverable = !isUndeliverable && isResidential && !isPostOfficeBox && !isPuertoRico
         const warning = DELIVERABILITY_WARNINGS[deliverability] || null
 
         if (!deliverable) {
-            let errorMessage = null
-            if (!isResidential) {
-                errorMessage = 'Non-residential addresses are not currently supported'
-            } else if (isPostOfficeBox) {
-                errorMessage = 'Post office boxes are not currently supported'
-            } else if (isPuertoRico) {
-                errorMessage = 'Puerto Rico addresses are not currently supported'
-            } else {
-                errorMessage = 'Address is undeliverable'
+            let errorMessage = 'Address is undeliverable'
+            if (!isUndeliverable) {
+                if (!isResidential) {
+                    errorMessage = 'Non-residential addresses are not currently supported'
+                } else if (isPostOfficeBox) {
+                    errorMessage = 'Post office boxes are not currently supported'
+                } else if (isPuertoRico) {
+                    errorMessage = 'Puerto Rico addresses are not currently supported'
+                }
             }
 
             return res.status(400).send({ error: errorMessage })

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -1,10 +1,22 @@
 const express = require('express')
 const axios = require('axios')
 const { createClient } = require('../../db')
+const Lob = require('lob')
+
 const router = express.Router()
 const db = createClient()
 
 const LOB_API_KEY = getLobApiKey()
+const lob = new Lob({ apiKey: LOB_API_KEY })
+
+const ALLOWED_ADDRESS_FIELDS = ['line1', 'line2', 'city', 'state', 'zip']
+const VALID_US_ZIP_CODE_MATCH = /^(?:\d{1,4}|\d{5}(?:[+-]?\d{4})?)$/
+const DELIVERABILITY_WARNINGS = {
+    undeliverable: 'Address is not deliverable',
+    deliverable_incorrect_unit: 'Address may be deliverable but contains a suite number that does not exist',
+    deliverable_missing_unit: 'Address may be deliverable but is missing a suite number',
+    deliverable_unnecessary_unit: 'Address may be deliverable but contains an unnecessary suite number'
+}
 
 router.get('/:templateId', async (req, res) => {
     const { templateId } = req.params
@@ -26,6 +38,104 @@ router.get('/:templateId', async (req, res) => {
         return res.status(200).send(templateInfo)
     }
     catch (error) {
+        return handleLobError(error, res)
+    }
+})
+
+router.post('/addressVerification', async (req, res) => {
+    const address = req.body
+
+    // Very rough schema validation
+    try {
+        const keys = Object.keys(address || {}).sort()
+        if (!address || keys.length === 0) {
+            throw new Error('Address object cannot be empty')
+        }
+
+        const disallowedKeys = keys.reduce(
+            (badKeys, key) => {
+                if (!ALLOWED_ADDRESS_FIELDS.includes(key)) {
+                    badKeys.push(key)
+                }
+                return badKeys
+            },
+            []
+        )
+
+        if (disallowedKeys.length > 0) {
+            throw new Error(`Address object contained unexpected keys: ${JSON.stringify(disallowedKeys)}`)
+        }
+
+        if (!(address.line1 || '').trim()) {
+            throw new Error('Address object must contain a primary line (line1)')
+        }
+
+        const { zip } = address
+        if (zip != null && typeof zip !== 'string') {
+            throw new Error('Address object must contain a string-based ZIP code')
+        }
+
+        let zipCode = (zip || '').trim()
+        if (zipCode) {
+            if (!VALID_US_ZIP_CODE_MATCH.test(zipCode)) {
+                throw new Error(`Address object contained an invalid ZIP code: ${zipCode}`)
+            }
+        } else if (!((address.city || '').trim() && (address.state || '').trim())) {
+            throw new Error('Address object must include both city and state, or a ZIP code')
+        }
+    } catch (validationError) {
+        return res.status(400).send({ error: validationError.message })
+    }
+
+    const { line1, line2, city, state, zip } = address
+    // Ensure the ZIP code is at least 5 digits
+    const zipCode = zip ? zip.padStart(5, '0') : null
+
+    try {
+        const response = await lob.usVerifications.verify({
+            primary_line: line1,
+            secondary_line: line2,
+            city,
+            state,
+            zip_code: zipCode
+        })
+
+        const {
+            deliverability,
+            components: {
+                state: stateAbbr,
+                address_type: addressType,
+                record_type: recordType
+            }
+        } = response.data
+
+        const undeliverable = !deliverability || deliverability === 'undeliverable'
+        const isResidential = addressType === 'residential'
+        const isPostOfficeBox = recordType === 'po_box'
+        const isPuertoRico = stateAbbr === 'PR'
+
+        const deliverable = !undeliverable && isResidential && !isPostOfficeBox && !isPuertoRico
+        const warning = DELIVERABILITY_WARNINGS[deliverability] || null
+
+        if (!deliverable) {
+            let errorMessage = null
+            if (!isResidential) {
+                errorMessage = 'Non-residential addresses are not currently supported'
+            } else if (isPostOfficeBox) {
+                errorMessage = 'Post office boxes are not currently supported'
+            } else if (isPuertoRico) {
+                errorMessage = 'Puerto Rico addresses are not currently supported'
+            } else {
+                errorMessage = 'Address is undeliverable'
+            }
+
+            return res.status(400).send({ error: errorMessage })
+        }
+
+        return res.status(200).send({ deliverable, warning })
+    } catch (error) {
+        // This endpoint should not return anything other than `200` status
+        // codes, even for undeliverable addresses
         return handleLobError(error, res)
     }
 })

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -102,8 +102,13 @@ router.post('/addressVerification', async (req, res) => {
 
         const {
             deliverability,
+            primary_line: revisedLine1,
+            secondary_line: revisedLine2,
             components: {
-                state: stateAbbr,
+                city: revisedCity,
+                state: revisedState,
+                zip_code: revisedZip,
+                zip_code_plus_4: revisedZipPlus4,
                 address_type: addressType,
                 record_type: recordType
             }
@@ -112,7 +117,7 @@ router.post('/addressVerification', async (req, res) => {
         const undeliverable = !deliverability || deliverability === 'undeliverable'
         const isResidential = addressType === 'residential'
         const isPostOfficeBox = recordType === 'po_box'
-        const isPuertoRico = stateAbbr === 'PR'
+        const isPuertoRico = revisedState === 'PR'
 
         const deliverable = !undeliverable && isResidential && !isPostOfficeBox && !isPuertoRico
         const warning = DELIVERABILITY_WARNINGS[deliverability] || null
@@ -132,7 +137,17 @@ router.post('/addressVerification', async (req, res) => {
             return res.status(400).send({ error: errorMessage })
         }
 
-        return res.status(200).send({ deliverable, warning })
+        return res.status(200).send({
+            deliverable,
+            warning,
+            revisedAddress: {
+                line1: revisedLine1,
+                line2: revisedLine2 || null,
+                city: revisedCity,
+                state: revisedState,
+                zip: revisedZip + (revisedZipPlus4 ? '-' + revisedZipPlus4 : '')
+            }
+        })
     } catch (error) {
         // This endpoint should not return anything other than `200` status
         // codes, even for undeliverable addresses

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -4,24 +4,82 @@ const { createClient } = require('../../db')
 const router = express.Router()
 const db = createClient()
 
-router.get('/:template_id', async (req, res) => {
-    const template_id = req.params.template_id;
-    var templateinfo = {};
+const LOB_API_KEY = getLobApiKey()
 
-    axios
-    .get('https://api.lob.com/v1/templates/'+template_id, {
-        auth: {
-            username: process.env.LiveLob,      
-        },
-    })
-    .then(function (response) {
-        templateinfo = response.data
-        res.send(templateinfo);
-    })
-    .catch(function (error) {
-        console.log(error)
-        res.status(500).send({ error: 'Whoops' });
-    })
-});
+router.get('/:templateId', async (req, res) => {
+    const { templateId } = req.params
+    var templateInfo = {}
+
+    try {
+        // We must use `axios` here as the `lob` package does not yet support
+        // the [beta] Templates API.
+        const response = axios.get(
+            `https://api.lob.com/v1/templates/${templateId}`,
+            {
+                auth: {
+                    username: LOB_API_KEY
+                }
+            }
+        )
+
+        templateInfo = response.data
+        return res.status(200).send(templateInfo)
+    }
+    catch (error) {
+        return handleLobError(error, res)
+    }
+})
 
 module.exports = router
+
+// Temporary implementation for fallback with deprecation warnings
+function getLobApiKey () {
+    const { LOB_API_KEY, LiveLob } = process.env
+    const lobApiKey = LOB_API_KEY || LiveLob
+
+    if (LiveLob) {
+        if (LOB_API_KEY) {
+            console.warn('Using "LOB_API_KEY" environment variable.')
+            console.warn(
+                'Please remove your deprecated "LiveLob" environment variable!'
+            )
+        } else {
+            console.warn(
+                'Expected "LOB_API_KEY" environment variable was not found.'
+            )
+            console.warn(
+                'Falling back to deprecated "LiveLob" environment variable....'
+            )
+            console.warn(
+                'Please update your environment to use the expected key!'
+            )
+        }
+    }
+
+    return lobApiKey
+}
+
+function handleLobError (error, res) {
+    let status = 500
+    let errorMessage = 'Whoops'
+
+    if (error) {
+        if (error.response) {
+            status = 502
+
+            const { status: statusCode, data: lobApiError } = error.response
+            console.error(`Lob API error (${statusCode}): ${JSON.stringify(lobApiError)}`)
+
+            // If the error is being blamed on the request...
+            // See: https://docs.lob.com/#errors
+            if ([400, 422].includes(statusCode)) {
+                status = 400
+                errorMessage = lobApiError.message
+            }
+        } else {
+            console.error(error)
+        }
+    }
+
+    return res.status(status).send({ error: errorMessage })
+}

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -18,7 +18,7 @@ const DELIVERABILITY_WARNINGS = {
     deliverable_unnecessary_unit: 'Address may be deliverable but contains an unnecessary suite number'
 }
 
-router.get('/:templateId', async (req, res) => {
+router.get(['/templates/:templateId', '/:templateId'], async (req, res) => {
     const { templateId } = req.params
     var templateInfo = {}
 

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -204,7 +204,9 @@ function handleLobError (error, res) {
                 lobApiError = error._response.body.error
             }
 
-            console.error(`Lob API error (${lobStatus}): ${JSON.stringify(lobApiError)}`)
+            if (process.env.NODE_ENV !== 'test') {
+                console.error(`Lob API error (${lobStatus}): ${JSON.stringify(lobApiError)}`)
+            }
 
             // If the error is being blamed on the request...
             // See: https://docs.lob.com/#errors

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -189,15 +189,30 @@ function handleLobError (error, res) {
     let errorMessage = 'Whoops'
 
     if (error) {
-        if (error.response) {
+        // error.response is from the `axios` package
+        // error._response is from the `lob` package
+        if (error.response || error._response) {
             status = 502
 
-            const { status: statusCode, data: lobApiError } = error.response
-            console.error(`Lob API error (${statusCode}): ${JSON.stringify(lobApiError)}`)
+            let lobStatus = null
+            let lobApiError = {}
+
+            // Handle Lob API errors from `axios` requests
+            if (error.response) {
+                lobStatus = error.response.status
+                lobApiError = error.response.data.error
+            }
+            // Handle Lob API errors from `lob` requests
+            else if (error._response) {
+                lobStatus = error._response.statusCode
+                lobApiError = error._response.body.error
+            }
+
+            console.error(`Lob API error (${lobStatus}): ${JSON.stringify(lobApiError)}`)
 
             // If the error is being blamed on the request...
             // See: https://docs.lob.com/#errors
-            if ([400, 422].includes(statusCode)) {
+            if ([400, 404, 422].includes(lobStatus)) {
                 status = 400
                 errorMessage = lobApiError.message
             }

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -25,7 +25,7 @@ router.get(['/templates/:templateId', '/:templateId'], async (req, res) => {
     try {
         // We must use `axios` here as the `lob` package does not yet support
         // the [beta] Templates API.
-        const response = axios.get(
+        const response = await axios.get(
             `https://api.lob.com/v1/templates/${templateId}`,
             {
                 auth: {

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -112,7 +112,7 @@ router.post('/addressVerification', async (req, res) => {
                 address_type: addressType,
                 record_type: recordType
             }
-        } = response.data
+        } = response
 
         const undeliverable = !deliverability || deliverability === 'undeliverable'
         const isResidential = addressType === 'residential'

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -6,9 +6,6 @@ const Lob = require('lob')
 const router = express.Router()
 const db = createClient()
 
-const LOB_API_KEY = getLobApiKey()
-const lob = new Lob({ apiKey: LOB_API_KEY })
-
 const ALLOWED_ADDRESS_FIELDS = ['line1', 'line2', 'city', 'state', 'zip']
 const VALID_US_ZIP_CODE_MATCH = /^(?:\d{1,4}|\d{5}(?:[+-]?\d{4})?)$/
 const DELIVERABILITY_WARNINGS = {
@@ -28,9 +25,7 @@ router.get(['/templates/:templateId', '/:templateId'], async (req, res) => {
         const response = await axios.get(
             `https://api.lob.com/v1/templates/${templateId}`,
             {
-                auth: {
-                    username: LOB_API_KEY
-                }
+                auth: { username: getLobApiKey() }
             }
         )
 
@@ -92,6 +87,7 @@ router.post('/addressVerification', async (req, res) => {
     const zipCode = zip ? zip.padStart(5, '0') : null
 
     try {
+        const lob = new Lob({ apiKey: getLobApiKey() })
         const response = await lob.usVerifications.verify({
             primary_line: line1,
             secondary_line: line2,


### PR DESCRIPTION
### Why?

Towards #36

### What Changed?

- Refined the existing Lob Templates API usage to use `await` for Promises
  - Added alternative endpoint `GET /api/lob/templates/:templateId` to `GET /api/lob/:templateId` to avoid vagueness
  - The old endpoint should be removed once the [frontend code using it](https://github.com/Ally-Guide/amplify-front-end/blob/7d22a6c0ff819f1a3e6794a886339ee11aca1b80/src/components/SearchReps.vue#L89-L91) can be updated
- Added a new API endpoint `POST /api/lob/addressVerification` for verifying US addresses via the Lob API
  - Also considers addresses that are non-residential, P.O. Boxes, or in Puerto Rico to be invalid. Are those all correct assumptions? Any other invalidating reasons to add? 🤔 cc @manishapriya94 

#### TODO

- [x] Update `.env.example` **and** contribution guide for `LOB_API_KEY`
- [x] Add integration tests?
- [x] Update [frontend code for retrieving a template](https://github.com/Ally-Guide/amplify-front-end/blob/7d22a6c0ff819f1a3e6794a886339ee11aca1b80/src/components/SearchReps.vue#L89-L91) to use the updated URL
  - https://github.com/Ally-Guide/amplify-front-end/pull/38
  - https://github.com/Ally-Guide/amplify-front-end/pull/39