### PR TITLE
Remove deprecated endpoint following frontend updates

### DIFF
--- a/server/__tests__/integration/lob.test.js
+++ b/server/__tests__/integration/lob.test.js
@@ -118,26 +118,6 @@ describe('GET /api/lob/templates/:templateId', () => {
     expect(spy).toHaveBeenCalled()
     spy.mockRestore()
   })
-
-  test('temporarily supports deprecated route /api/lob/:templateId', async () => {
-    const spy = jest.spyOn(axios, 'get')
-    spy.mockImplementation((url) => {
-      if (url !== `${LOB_API_HOST}/v1/templates/${templateId}`) {
-        throw new Error('unexpected call to `axios.get`')
-      }
-      return {
-        status: 200,
-        data: exampleLobResponse
-      }
-    })
-
-    const deprecatedRoute = `/api/lob/${templateId}`
-    const response = await request(app).get(deprecatedRoute)
-    expect(response.status).toBe(200)
-
-    expect(spy).toHaveBeenCalled()
-    spy.mockRestore()
-  })
 })
 
 describe('POST /api/lob/addressVerification', () => {

--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -16,7 +16,7 @@ const DELIVERABILITY_WARNINGS = {
     'Address may be deliverable but contains an unnecessary suite number'
 }
 
-router.get(['/templates/:templateId', '/:templateId'], async (req, res) => {
+router.get('/templates/:templateId', async (req, res) => {
   const { templateId } = req.params
   var templateInfo = {}
 


### PR DESCRIPTION
### Why?

Follows https://github.com/Ally-Guide/amplify-back-end/pull/79

### What Changed?

- Removed deprecated API endpoint `/api/lob/:templateId` in favor of the more specific `/api/lob/templates/:templateId`
- Removed associated integration test